### PR TITLE
feat: 自动拦截微信授权回调，避免跳转到404页面

### DIFF
--- a/README.md
+++ b/README.md
@@ -700,10 +700,15 @@ const shareToWeChat = async () => {
 > 微信授权结束后，会通过URL Scheme和通用链接来回到你的应用，并把授权结果带在路径上作为参数。比如`/wxauth/wx1234567890/oauth`
 > 如果你使用了expo-router，或者配置好了React Navigation的deep linking，那么导航器会尝试跳转到这个URL对应的路由下，由于路由不存在，就会显示404页面。
 
-#### 解决方案1
-既然这个问题产生的原因其实就是微信打开你的app的链接和你准备接收回调的链接没有“对准”，那么解决方案就是你想办法让它俩对准即可。在通用链接上和路由配置上想想办法。
+#### ✅ 自动解决方案（推荐）
+本插件已内置了解决方案，会自动拦截微信 Universal Link 回调，阻止 expo-router 处理，避免跳转到 404 页面。
 
-#### 解决方案2
+插件会自动检测包含 `/wx[a-zA-Z0-9]{16}/` 模式的 URL，确保只有 WeChat SDK 处理回调，无需任何手动配置。
+
+#### 替代方案1：手动对齐链接
+既然这个问题产生的原因其实就是微信打开你的app的链接和你准备接收回调的链接没有”对准”，那么解决方案就是你想办法让它俩对准即可。在通用链接上和路由配置上想想办法。
+
+#### 替代方案2：expo-router 拦截
 expo-router提供了一个API，可以让你拦截所有deep link，并手动控制是否处理。详见[Customizing links](https://docs.expo.dev/router/advanced/native-intent/#rewrite-incoming-native-deep-links)。
 简单来说，你需要新建一个`+native-intent.tsx`文件，按照文档导出一个函数，并根据条件，重定向到你的登录页面即可。
 

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -1,9 +1,8 @@
 import {
-  AndroidConfig,
   ConfigPlugin,
-  withAndroidManifest,
   withInfoPlist,
-} from "expo/config-plugins";
+  withAppDelegate,
+} from 'expo/config-plugins';
 
 const withExpoWechat: ConfigPlugin = (config) => {
   // config = withAndroidManifest(config, (config) => {
@@ -16,16 +15,51 @@ const withExpoWechat: ConfigPlugin = (config) => {
   config = withInfoPlist(config, (config) => {
     let queriesSchemes = config.modResults.LSApplicationQueriesSchemes ?? [];
     queriesSchemes.unshift(
-      "weixin",
-      "weixinULAPI",
-      "weixinURLParamsAPI",
-      "weixinQRCodePayAPI"
+      'weixin',
+      'weixinULAPI',
+      'weixinURLParamsAPI',
+      'weixinQRCodePayAPI',
     );
     queriesSchemes = [...new Set(queriesSchemes)];
     config.modResults.LSApplicationQueriesSchemes = queriesSchemes;
     return config;
   });
+  config = withAppDelegate(config, (config) => {
+    const appDelegate = config.modResults.contents;
+    if (!appDelegate) {
+      return config;
+    }
 
+    const methodPattern =
+      /public override func application\(\s*_ application: UIApplication,\s*continue userActivity: NSUserActivity,\s*restorationHandler: @escaping \(\[UIUserActivityRestoring\]\?\) -> Void\s*\) -> Bool \{[\s\S]*?\n  \}/;
+
+    const replacementMethod = `public override func application(
+    _ application: UIApplication,
+    continue userActivity: NSUserActivity,
+    restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void
+  ) -> Bool {
+    // 微信 Universal Link 回调阻止 expo-router 处理，只让 WeChat SDK 处理 @expo-wechat
+    if let webpageURL = userActivity.webpageURL {
+      let urlString = webpageURL.absoluteString
+      // 精确匹配微信 appid 确保是微信链接
+      if urlString.contains("/wx") {
+        let wxPattern = "/wx[a-zA-Z0-9]{16}/"
+        if let range = urlString.range(of: wxPattern, options: .regularExpression) {
+          return super.application(application, continue: userActivity, restorationHandler: restorationHandler)
+        }
+      }
+    }
+
+    let result = RCTLinkingManager.application(application, continue: userActivity, restorationHandler: restorationHandler)
+    return super.application(application, continue: userActivity, restorationHandler: restorationHandler) || result
+  }`;
+
+    config.modResults.contents = appDelegate.replace(
+      methodPattern,
+      replacementMethod,
+    );
+    return config;
+  });
   return config;
 };
 


### PR DESCRIPTION
插件现已内置微信 Universal Link 回调拦截功能，自动检测并阻止
expo-router 处理微信授权回调，解决授权结束后跳转到404页面的问题。